### PR TITLE
feat: add local Dagger installation support and helper targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,18 @@
 all: build
 
+# Install Dagger locally if not available
+.PHONY: install-dagger
+install-dagger:
+	@if ! which dagger >/dev/null 2>&1 && [ ! -f ./bin/dagger ]; then \
+		echo "Installing Dagger locally..."; \
+		mkdir -p bin; \
+		curl -L https://dl.dagger.io/dagger/install.sh | DAGGER_INSTALL_DIR=./bin sh; \
+	fi
+
 .PHONY: build
-build:
+build: install-dagger
 	@which docker >/dev/null || ( echo "Please follow instructions to install Docker at https://docs.docker.com/get-started/get-docker/"; exit 1 )
-	@docker build --platform local -o . .
+	@export PATH="./bin:$$PATH" && docker build --platform local -o . .
 	@ls cu
 
 .PHONY: clean
@@ -32,3 +41,16 @@ install: build
 	fi; \
 	echo "Installing cu to $$DEST..."; \
 	mv cu "$$DEST/"
+
+# Run the MCP server with proper PATH setup
+.PHONY: run-server
+run-server: install-dagger
+	@export PATH="./bin:$$PATH" && ./cu stdio
+
+# Helper target to check if everything is set up correctly
+.PHONY: check-setup
+check-setup: install-dagger
+	@echo "Checking setup..."
+	@export PATH="./bin:$$PATH" && which dagger >/dev/null && echo "✓ Dagger is available" || echo "✗ Dagger not found"
+	@which docker >/dev/null && echo "✓ Docker is available" || echo "✗ Docker not found"
+	@[ -f ./cu ] && echo "✓ cu binary exists" || echo "✗ cu binary not found"


### PR DESCRIPTION
## Summary
- Adds automatic local Dagger installation to simplify developer setup
- Introduces helper targets for environment verification and MCP server execution

## Changes
- **install-dagger**: New target that installs Dagger locally in `./bin` if not already available
- **build**: Now depends on `install-dagger` to ensure Dagger is available before building
- **run-server**: New target to run the MCP server with proper PATH configuration
- **check-setup**: New helper target to verify that all required tools are properly installed

## Benefits
- Removes the need to manually install Dagger globally before building
- Provides clear feedback about the setup status
- Simplifies the MCP server execution with proper PATH handling

## Test plan
- [x] Run `make check-setup` to verify environment detection
- [x] Run `make build` to ensure automatic Dagger installation works
- [ ] Verify the build process completes successfully
- [ ] Test `make run-server` after build completes

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved environment setup by automating the installation and management of required tools.
  - Added checks to verify the presence of necessary dependencies before running build and server commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->